### PR TITLE
Don't include vendor path in package path

### DIFF
--- a/pkg/deps_test.go
+++ b/pkg/deps_test.go
@@ -168,3 +168,14 @@ func assertSetsEqual(t *testing.T, actual, expected Set, ctx string) {
 		assert.Contains(t, expected, k, "[%s] Unexpected item %s", ctx, k)
 	}
 }
+
+func TestStripVendor(t *testing.T) {
+	tests := []struct{ path, expected string }{
+		{"github.com/google/godepq/vendor/github.com/google/cadvisor/manager", "github.com/google/cadvisor/manager"},
+		{"/vendor/github.com/google/cadvisor/manager", "github.com/google/cadvisor/manager"},
+		{"github.com/google/cadvisor/manager", "github.com/google/cadvisor/manager"},
+	}
+	for _, test := range tests {
+		assert.Equal(t, test.expected, stripVendor(test.path), "stripVendor(%s)", test.path)
+	}
+}


### PR DESCRIPTION
`build.Context.Import` searches vendor directories, and will include the vendor path in the `ImportPath`. This causes the graph construction to fail, the vendor paths don't match the real path names.

Before:

```
$ godepq -from ./cmd/kubelet -to github.com/google/cadvisor/storage
No path found from "k8s.io/kubernetes/cmd/kubelet" to "k8s.io/kubernetes/vendor/github.com/google/cadvisor/storage"
```

After:

```
$ godepq -from k8s.io/kubernetes/cmd/kubelet -to github.com/google/cadvisor/storage
Packages:
  k8s.io/kubernetes/cmd/kubelet
  k8s.io/kubernetes/cmd/kubelet/app
  k8s.io/kubernetes/pkg/kubelet/server
  k8s.io/kubernetes/pkg/kubelet/server/stats
  k8s.io/kubernetes/pkg/kubelet/cm
  k8s.io/kubernetes/pkg/kubelet/cadvisor
  github.com/google/cadvisor/cache/memory
  github.com/google/cadvisor/storage
```
